### PR TITLE
add encoding

### DIFF
--- a/8.1-text-generation-with-lstm.ipynb
+++ b/8.1-text-generation-with-lstm.ipynb
@@ -74,7 +74,7 @@
     "path = keras.utils.get_file(\n",
     "    'nietzsche.txt',\n",
     "    origin='https://s3.amazonaws.com/text-datasets/nietzsche.txt')\n",
-    "text = open(path).read().lower()\n",
+    "text = open(path, encoding="utf-8").read().lower()\n",
     "print('말뭉치 크기:', len(text))"
    ]
   },


### PR DESCRIPTION
nietzsche.txt 파일은 UTF-8로 인코딩되어 있는것으로 보입니다.
chardetect nietzsche.txt
nietzsche.txt: utf-8 with confidence 0.99

utf-8이 기본 캐릭터셋이 되어 있지 않은 윈도우 환경에서는 파일을 읽을때에 에러가 발생할수 있습니다.